### PR TITLE
modify file lists as quick fix to allow compilation

### DIFF
--- a/ice_ocean_SIS2_symmetric/gen_build.sh
+++ b/ice_ocean_SIS2_symmetric/gen_build.sh
@@ -19,7 +19,7 @@ fsrc_files+=($(find -L ${srcdir}/MOM6/config_src/drivers/FMS_cap -iname '*.f90')
 fsrc_files+=($(find -L ${srcdir}/MOM6/config_src/external -iname '*.f90'))
 fsrc_files+=($(find -L ${srcdir}/SIS2 -iname '*.f90'))
 # coupler files
-fsrc_files+=($(find -L ${srcdir}/{atmos_null,coupler,land_null,ice_param,icebergs} -iname '*.f90'))
+fsrc_files+=($(find -L ${srcdir}/{atmos_null,coupler,land_null,ice_param,icebergs/src} -iname '*.f90'))
 fsrc_files+=($(find -L ${srcdir}/FMS/coupler -iname '*.f90'))
 objs=()
 


### PR DESCRIPTION
Just implementing your quick fix here. Can confirm it worked with latest mom6 code as of today but you might want to do it properly.

For others who want to compile mom6 and come across this: Changes to the iceberg module have broken this workflow for the sis-ocean compilation. Using this branch might work for you instead