### PR TITLE
Modifications to `gen_build.sh` to compile ice-ocean coupled model

### DIFF
--- a/ice_ocean_SIS2_symmetric/gen_build.sh
+++ b/ice_ocean_SIS2_symmetric/gen_build.sh
@@ -17,12 +17,12 @@ EOF
 
 # lists of source files
 fsrc_files=($(find -L ${srcdir}/MOM6/src -iname '*.f90'))
-fsrc_files+=($(find -L ${srcdir}/MOM6/config_src/infra/FMS2 -iname '*.f90'))
+fsrc_files+=($(find -L ${srcdir}/MOM6/config_src/infra/FMS1 -iname '*.f90'))
 fsrc_files+=($(find -L ${srcdir}/MOM6/config_src/drivers/FMS_cap -iname '*.f90'))
 fsrc_files+=($(find -L ${srcdir}/MOM6/config_src/external -iname '*.f90'))
 fsrc_files+=($(find -L ${srcdir}/SIS2 -iname '*.f90'))
 # coupler files
-fsrc_files+=($(find -L ${srcdir}/{atmos_null,coupler/{full,shared},land_null,ice_param,icebergs/src} -iname '*.f90'))
+fsrc_files+=($(find -L ${srcdir}/{atmos_null,coupler,land_null,ice_param,icebergs/src} -iname '*.f90'))
 fsrc_files+=($(find -L ${srcdir}/FMS/coupler -iname '*.f90'))
 objs=()
 


### PR DESCRIPTION
I was unable to compile MOM6 + SIS2 using the scripts as-is. Comparing with the GFDL instructions [here](https://github.com/NOAA-GFDL/MOM6-examples/wiki/Getting-started#compiling-mom6-in-mom6-sis2-coupled-mode) I made a couple of minor tweaks and was able to compile the model.

I've yet to run the compiled binary, but wanted to start this PR so that I didn't forget. 

