### PR TITLE
Modifications to gen_build.sh to compile ice-ocean coupled model #2

### DIFF
--- a/ice_ocean_SIS2_symmetric/gen_build.sh
+++ b/ice_ocean_SIS2_symmetric/gen_build.sh
@@ -14,13 +14,15 @@ EOF
 
 # lists of source files
 fsrc_files=($(find -L ${srcdir}/MOM6/src -iname '*.f90'))
-fsrc_files+=($(find -L ${srcdir}/MOM6/config_src/infra/FMS2 -iname '*.f90'))
+fsrc_files+=($(find -L ${srcdir}/MOM6/config_src/infra/FMS1 -iname '*.f90'))
 fsrc_files+=($(find -L ${srcdir}/MOM6/config_src/external -iname '*.f90'))
 fsrc_files+=($(find -L ${srcdir}/MOM6/config_src/drivers/FMS_cap -iname '*.f90'))
 fsrc_files+=($(find -L ${srcdir}/SIS2 -iname '*.f90'))
 # coupler files
-fsrc_files+=($(find -L ${srcdir}/{atmos_null,coupler/full,coupler/shared,land_null,ice_param,icebergs/src} -iname '*.f90'))
+fsrc_files+=($(find -L ${srcdir}/{atmos_null,coupler,land_null,ice_param,icebergs/src} -iname '*.f90'))
 fsrc_files+=($(find -L ${srcdir}/FMS/coupler -iname '*.f90'))
+
+
 objs=()
 
 # build module provides for fortran files


### PR DESCRIPTION
_Very_ similar to [this](https://github.com/angus-g/mom6-ninja-nci/pull/8), this change allows a standalone build of MOM6 + SIS2 on Gadi. 

Provided one uses this commit (a8ebabaa808fa700bcdd1f710199d6b01e8b1f67) and MOM6-examples (1bddc655f0bb4d38ef0398a7f4d5545c5529b920). Follow steps here (https://github.com/angus-g/mom6-ninja-nci) except for the #3 setup step. On this repo, need to additionally add `src` path here: `mom6-ninja-nci/gen_build.sh`.

Some environment details include:
```
module purge
module load openmpi/4.1.4
module load intel-compiler/2021.8.0
module load netcdf/4.9.2
#fork of [GitHub - angus-g/mom6-ninja-nci: Painless shell scripts to set up a ninja build of MOM6 on NCI HPC](https://github.com/angus-g/mom6-ninja-nci) with *all branches*
git clone [git@github.com](mailto:git@github.com):chrisb13/mom6-ninja-nci.git
cd mom6-ninja-nci
git checkout a8ebabaa808fa700bcdd1f710199d6b01e8b1f67
cd /home/561/cyb561/MOM6-examples2
git checkout 1bddc655f0bb4d38ef0398a7f4d5545c5529b920
#add src path to mom6-ninja-nci/gen_build.sh
#build using Angus' readme
```


Thanks to @angus-g and @edoddridge for the tips!